### PR TITLE
Allow for external manage of horizon

### DIFF
--- a/manifests/dashboard.pp
+++ b/manifests/dashboard.pp
@@ -45,6 +45,10 @@
 #  (Optional) Whether to sync database
 #  Default to 'true'
 #
+# [*manage_horizon*]
+# (Optional) Whether horizon's conf is managed here or externally
+# Default to 'true'
+#
 class murano::dashboard(
   $package_ensure        = 'present',
   $repo_url              = undef,
@@ -55,6 +59,7 @@ class murano::dashboard(
   $dashboard_debug_level = 'DEBUG',
   $client_debug_level    = 'ERROR',
   $sync_db               = true,
+  $manage_horizon        = true,
   # DEPRECATED PARAMETERS
   $api_url               = undef,
 ) {
@@ -71,7 +76,7 @@ class murano::dashboard(
     tag    => ['openstack', 'murano-packages'],
   }
 
-  concat { $::murano::params::local_settings_path: }
+  if $manage_horizon { concat { $::murano::params::local_settings_path: } }
 
   concat::fragment { 'original_config':
     target => $::murano::params::local_settings_path,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -301,26 +301,26 @@ class murano(
 
     'oslo_messaging_rabbit/rabbit_userid' :    value => $rabbit_os_user;
     'oslo_messaging_rabbit/rabbit_password' :  value => $rabbit_os_password;
-    'oslo_messaging_rabbit/rabbit_hosts' :     value => $rabbit_os_host;
+    'oslo_messaging_rabbit/rabbit_hosts' :     value => join(any2array($rabbit_os_host), ',');
     'oslo_messaging_rabbit/rabbit_port' :      value => $rabbit_os_port;
     'oslo_messaging_rabbit/rabbit_ha_queues' : value => $rabbit_ha_queues;
 
     'rabbitmq/login' :                         value => $rabbit_own_user;
     'rabbitmq/password' :                      value => $rabbit_own_password;
-    'rabbitmq/host' :                          value => $rabbit_own_host;
+    'rabbitmq/host' :                          value => join(any2array($rabbit_own_host), ',');
     'rabbitmq/port' :                          value => $rabbit_own_port;
     'rabbitmq/virtual_host' :                  value => $rabbit_own_vhost;
 
-    'keystone_authtoken/auth_uri' :          value => $auth_uri;
-    'keystone_authtoken/admin_user' :        value => $admin_user;
-    'keystone_authtoken/admin_tenant_name' : value => $admin_tenant_name;
-    'keystone_authtoken/signing_dir' :       value => $signing_dir;
-    'keystone_authtoken/admin_password' :    value => $admin_password;
-    'keystone_authtoken/identity_uri' :      value => $identity_uri;
+    'keystone_authtoken/auth_uri' :            value   => $auth_uri;
+    'keystone_authtoken/admin_user' :          value   => $admin_user;
+    'keystone_authtoken/admin_tenant_name' :   value   => $admin_tenant_name;
+    'keystone_authtoken/signing_dir' :         value   => $signing_dir;
+    'keystone_authtoken/admin_password' :      value   => $admin_password;
+    'keystone_authtoken/identity_uri' :        value   => $identity_uri;
 
-    'networking/default_dns':                value => $default_nameservers;
+    'networking/default_dns':                  value   => $default_nameservers;
 
-    'packages_opts/packages_service':        value => $packages_service,
+    'packages_opts/packages_service':          value   => $packages_service,
   }
 
   if $sync_db {

--- a/manifests/keystone/auth.pp
+++ b/manifests/keystone/auth.pp
@@ -51,6 +51,13 @@
 #   (optional) The endpoint's internal url. (Defaults to 'http://127.0.0.1:8082
 #   This url should *not* contain any trailing '/'.
 #
+# [*configure_user*]
+#   Tell keystone to configure the user or not
+#   Defaults to true
+#
+# [*configure_user_role*]
+#   Tell keystone to configure the user role or not
+#   Defaults to true
 # === Examples
 #
 #  class { 'murano::keystone::auth':
@@ -73,13 +80,15 @@ class murano::keystone::auth(
   $public_url          = 'http://127.0.0.1:8082',
   $admin_url           = 'http://127.0.0.1:8082',
   $internal_url        = 'http://127.0.0.1:8082',
+  $configure_user      = true,
+  $configure_user_role = true,
 ) {
 
   $real_service_name = pick($service_name, $auth_name)
 
   keystone::resource::service_identity { $real_service_name:
-    configure_user      => true,
-    configure_user_role => true,
+    configure_user      => $configure_user,
+    configure_user_role => $configure_user_role,
     configure_endpoint  => $configure_endpoint,
     service_type        => $service_type,
     service_description => $service_description,


### PR DESCRIPTION
If you use both the puppet-horizon and puppet-murano module, you'll get
a duplicate resource error since they both declare the initial concat
resource on horizon's config.  This adds a flag to allow for murano to
not initially delcare the file

This also fixes a few other issues we have with this module